### PR TITLE
Make sure we only signal the scheduler when it is still running

### DIFF
--- a/Core/Types/Next.Core.Promises.pas
+++ b/Core/Types/Next.Core.Promises.pas
@@ -513,8 +513,9 @@ begin
   //Signal Await that we are done
   FSignal.SetEvent;
 
-  //Signal scheduler that we are done
-  _Scheduler.Signal;
+  //Signal scheduler that we are done, but only if the scheduler is not being destroyed
+  if Assigned(_Scheduler) then
+    _Scheduler.Signal;
 end;
 
 procedure TAbstractPromise<T>.Resolve(AValue: TDisposableValue<T>);
@@ -530,8 +531,9 @@ begin
   //Signal Await that we are done
   FSignal.SetEvent;
 
-  //Signal scheduler that we are done
-  _Scheduler.Signal;
+  //Signal scheduler that we are done, but only if the scheduler is not being destroyed
+  if Assigned(_Scheduler) then
+    _Scheduler.Signal;
 end;
 
 procedure TAbstractPromise<T>.SetFailure(AFailure: IFailureReason);


### PR DESCRIPTION
When you close your application and there is a pending promise which is being executed, you will get an access violation as soon as the promise is fulfilled. This is now solved by checking whether the scheduler is still assigned.