### PR TITLE
Windows API dependency removal

### DIFF
--- a/Core/Types/Next.Core.DisposableValue.pas
+++ b/Core/Types/Next.Core.DisposableValue.pas
@@ -35,7 +35,7 @@ procedure SetFlagInterface(var Intf: IInterface);
 implementation
 
 uses
-  System.Rtti, Winapi.Windows, Spring.Reflection;
+  System.Rtti;
 
 function NopAddref(inst: Pointer): Integer; stdcall;
 begin
@@ -70,9 +70,20 @@ end;
 { TDisposableValue<T> }
 
 class operator TDisposableValue<T>.Implicit(const dv: TDisposableValue<T>): T;
+var
+  LCtx: TRttiContext;
+  LName: string;
 begin
   if not dv.HasValue() then
-    raise EDisposableValueException.Create('DisposableValue<' + TType.GetType(System.TypeInfo(T)).Name + '> has no value set');
+  begin
+    LCtx := TRttiContext.Create;
+    try
+      LName := LCtx.GetType(System.TypeInfo(T)).Name;
+    finally
+      LCtx.Free;
+    end;
+    raise EDisposableValueException.Create('DisposableValue<' + LName + '> has no value set');
+  end;
 
   Result := dv.FValue;
 end;

--- a/Core/Types/Next.Core.Promises.pas
+++ b/Core/Types/Next.Core.Promises.pas
@@ -953,12 +953,12 @@ begin
     AddThread();
 
   while (not LCancel) do begin
-    {$IFDEF MSWINDOWS}
+{$IFDEF MSWINDOWS}
     const LWaitResult = WaitForMultipleObjectsEx(2, @LEvents, False, INFINITE, False);
-    {$ENDIF}
-    {$IFNDEF MSWINDOWS}
+{$ENDIF}
+{$IFNDEF MSWINDOWS}
     const LWaitResult = WaitForMultipleEvents(LEvents);
-    {$ENDIF}
+{$ENDIF}
     case LWaitResult of
       WAIT_OBJECT_0: LCancel := True;
 
@@ -1347,7 +1347,7 @@ const
 {$ENDIF}
 begin
   inherited;
-{$IFNDEF MSWINDOWS}
+{$IFDEF MSWINDOWS}
   LEvents[0] := FCancel.Handle;
   LEvents[1] := FScheduler.SignalToken.Handle;
 {$ENDIF}

--- a/Core/Types/Next.Core.Promises.pas
+++ b/Core/Types/Next.Core.Promises.pas
@@ -944,7 +944,7 @@ begin
   LEvents[1] := FSignalController.Handle;
 {$ENDIF}
 {$IFNDEF MSWINDOWS}
-  LEvents[0] := FCancel.Handle;
+  LEvents[0] := FCancel;
   LEvents[1] := FSignalController;
 {$ENDIF}
   var LCancel := False;


### PR DESCRIPTION
In order to support cross-platform targeting:
- Removed Windows.Winapi unit
- Removed Spring.Reflection unit
- Replaced WaitForMultipleObjectsEx with a custom WaitForMultipleEvents implementation