### PR TITLE
Call Await twice on rejected promise can cause runtime error

### DIFF
--- a/Test/Types/Next.Core.TestFailureReason.pas
+++ b/Test/Types/Next.Core.TestFailureReason.pas
@@ -15,6 +15,8 @@ type
     procedure NoValidException;
     [Test]
     procedure DetachException;
+    [Test]
+    procedure ExpectSuccessiveDetachExceptionToGiveClonedException;
   end;
 
 implementation
@@ -41,6 +43,26 @@ begin
   end;
 
   Assert.IsNull(LReason.Reason);
+end;
+
+procedure TTestFailureReason.ExpectSuccessiveDetachExceptionToGiveClonedException;
+var
+  LReason: IFailureReason;
+  LException: Exception;
+begin
+  LReason := TFailureReason.Create(ETestException.Create('My Exception'));
+
+  //First detach is the original exception
+  LException := LReason.DetachExceptionObject;
+  Assert.InheritsFrom(LException.ClassType, ETestException);
+  Assert.AreEqual('My Exception', LException.Message);
+
+  //Successive detaches are clones of the original exception
+  for var i := 0 to 10 do begin
+    LException := LReason.DetachExceptionObject;
+    Assert.InheritsFrom(LException.ClassType, ETestException);
+    Assert.AreEqual('My Exception', LException.Message);
+  end;
 end;
 
 procedure TTestFailureReason.FailureReason;


### PR DESCRIPTION
Thanks for taking the time to fill out a bug report! Please make sure to be as specific as possible in your description and title.

**Issue description**
If you call Await twice on a rejected promise, the second time will throw a `nil` exception, which can lead to a total application crash with a runtime error. This is not caught by the Delphi exception handler. While this is normally an indication of an error in your codeflow, this is behavior that should be supported.

**Steps to reproduce**
```
var fail := Promise.Reject<TVoid>(Exception.Create('error'));

for var i := 0 to 5 do begin
  try
    fail.Await;
  except
  end;
end;
```